### PR TITLE
Ignore history cookie

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -779,6 +779,7 @@ history_load(TYPE(History) *h, const char *fname)
 	size_t max_size;
 	char *ptr;
 	int i = -1;
+	int first_line = 1;
 	TYPE(HistEvent) ev;
 	Char *decode_result;
 #ifndef NARROWCHAR
@@ -793,13 +794,22 @@ history_load(TYPE(History) *h, const char *fname)
 	if ((sz = getline(&line, &llen, fp)) == -1)
 		goto done;
 
-	if (strncmp(line, hist_cookie, (size_t)sz) != 0)
-		goto done;
-
 	ptr = h_malloc((max_size = 1024) * sizeof(*ptr));
 	if (ptr == NULL)
 		goto done;
-	for (i = 0; (sz = getline(&line, &llen, fp)) != -1; i++) {
+
+	i = 0;
+	do {
+		/*
+		 * The history file may or may not have the cookie on the first line.
+		 * If the first line is the cookie, then start reading the history
+		 * from the second line. Otherwise, start reading from the first line.
+		 */
+		if (first_line && strncmp(line, hist_cookie, (size_t)sz) == 0) {
+			first_line = 0;
+			continue;
+		}
+		first_line = 0;
 		if (sz > 0 && line[sz - 1] == '\n')
 			line[--sz] = '\0';
 		if (max_size < (size_t)sz) {
@@ -814,13 +824,16 @@ history_load(TYPE(History) *h, const char *fname)
 		}
 		(void) strunvis(ptr, line);
 		decode_result = ct_decode_string(ptr, &conv);
-		if (decode_result == NULL)
+		if (decode_result == NULL) {
+			i++;
 			continue;
+		}
 		if (HENTER(h, &ev, decode_result) == -1) {
 			i = -1;
 			goto oomem;
 		}
-	}
+		i++;
+	} while ((sz = getline(&line, &llen, fp)) != -1);
 oomem:
 	h_free(ptr);
 done:

--- a/src/history.c
+++ b/src/history.c
@@ -793,13 +793,12 @@ history_load(TYPE(History) *h, const char *fname)
 	if ((sz = getline(&line, &llen, fp)) == -1)
 		goto done;
 
-	if (strncmp(line, hist_cookie, (size_t)sz) != 0)
-		goto done;
-
 	ptr = h_malloc((max_size = 1024) * sizeof(*ptr));
 	if (ptr == NULL)
 		goto done;
-	for (i = 0; (sz = getline(&line, &llen, fp)) != -1; i++) {
+	for (i = 0; (sz = getline(&line, &llen, fp)) != -1;) {
+		if (i == 0 && strncmp(line, hist_cookie, (size_t)sz) != 0)
+			continue;
 		if (sz > 0 && line[sz - 1] == '\n')
 			line[--sz] = '\0';
 		if (max_size < (size_t)sz) {
@@ -820,6 +819,7 @@ history_load(TYPE(History) *h, const char *fname)
 			i = -1;
 			goto oomem;
 		}
+		i++;
 	}
 oomem:
 	h_free(ptr);

--- a/src/history.c
+++ b/src/history.c
@@ -801,7 +801,7 @@ history_load(TYPE(History) *h, const char *fname)
 	i = 0;
 	do {
 		/*
-		 * The history file may or may not have the cookie on the first line.
+		 * YB: The history file may or may not have the cookie on the first line.
 		 * If the first line is the cookie, then start reading the history
 		 * from the second line. Otherwise, start reading from the first line.
 		 */


### PR DESCRIPTION
Currently, we have an issue (https://github.com/yugabyte/yugabyte-db/issues/9861) that causes ysqlsh history to not work between sessions.

We truncate the history file to the size limit (default 500) each time we write to it, keeping the 500 newest history commands and deleting the older ones. Libedit keeps a cookie at the beginning of the history file (after the oldest line of history). During truncation, the cookie gets deleted. The next time we try to load the history file, libedit sees that the cookie is missing and does not load the history file. This is a bug in libedit and is known to affect vanilla PostgreSQL as well.

This PR fixes this by loading the file even if the cookie is missing. It does not change the truncate behavior, so it still deletes the cookie when truncating a file that is longer than the limit.

Tests here: https://phorge.dev.yugabyte.com/D49360